### PR TITLE
Add tmux dev layout functions and omarchy PATH

### DIFF
--- a/conf.d/envs.fish
+++ b/conf.d/envs.fish
@@ -10,3 +10,7 @@ set -gx FZF_DEFAULT_OPTS '--cycle --layout=default --height=90% --preview-window
 
 # Ensure fzf history search shows preview (empty to not override the built-in preview)
 set -gx fzf_history_opts
+
+# Omarchy PATH - required for omarchy-* commands to work
+fish_add_path $HOME/.local/share/omarchy/bin
+fish_add_path $HOME/.local/bin

--- a/functions/tdl.fish
+++ b/functions/tdl.fish
@@ -1,0 +1,33 @@
+function tdl
+    if test -z "$argv[1]"
+        echo "Usage: tdl <c|cx|codex|other_ai> [<second_ai>]"
+        return 1
+    end
+
+    if not tmux display-message -p -t $TMUX_PANE &>/dev/null
+        echo "You must start tmux to use tdl."
+        return 1
+    end
+
+    set -l current_dir (pwd)
+    set -l ai $argv[1]
+    set -l ai2 $argv[2]
+    set -l editor_pane $TMUX_PANE
+
+    tmux rename-window -t $editor_pane (basename $current_dir)
+
+    tmux split-window -v -p 15 -t $editor_pane -c $current_dir
+
+    set -l ai_pane (tmux split-window -h -p 30 -t $editor_pane -c $current_dir -P -F '#{pane_id}')
+
+    if test -n "$ai2"
+        set -l ai2_pane (tmux split-window -v -t $ai_pane -c $current_dir -P -F '#{pane_id}')
+        tmux send-keys -t $ai2_pane "$ai2" C-m
+    end
+
+    tmux send-keys -t $ai_pane "$ai" C-m
+
+    set -q EDITOR && tmux send-keys -t $editor_pane "$EDITOR ." C-m
+
+    tmux select-pane -t $editor_pane
+end

--- a/functions/tdlm.fish
+++ b/functions/tdlm.fish
@@ -1,0 +1,33 @@
+function tdlm
+    if test -z "$argv[1]"
+        echo "Usage: tdlm <c|cx|codex|other_ai> [<second_ai>]"
+        return 1
+    end
+
+    if not tmux display-message -p -t $TMUX_PANE &>/dev/null
+        echo "You must start tmux to use tdlm."
+        return 1
+    end
+
+    set -l ai $argv[1]
+    set -l ai2 $argv[2]
+    set -l base_dir (pwd)
+    set -l first true
+
+    set -l session_name (basename $base_dir | tr '.:' '--')
+    tmux rename-session $session_name
+
+    for dir in $base_dir/*/
+        if test -d "$dir"
+            set -l dirpath (string trim --right --chars=/ "$dir")
+
+            if test "$first" = "true"
+                tmux send-keys -t $TMUX_PANE "cd '$dirpath' && tdl $ai $ai2" C-m
+                set -l first false
+            else
+                set -l pane_id (tmux new-window -c "$dirpath" -P -F '#{pane_id}')
+                tmux send-keys -t $pane_id "tdl $ai $ai2" C-m
+            end
+        end
+    end
+end

--- a/functions/tsl.fish
+++ b/functions/tsl.fish
@@ -1,0 +1,31 @@
+function tsl
+    if test (count $argv) -lt 2
+        echo "Usage: tsl <pane_count> <command>"
+        return 1
+    end
+
+    if not tmux display-message -p -t $TMUX_PANE &>/dev/null
+        echo "You must start tmux to use tsl."
+        return 1
+    end
+
+    set -l count $argv[1]
+    set -l cmd $argv[2]
+    set -l current_dir (pwd)
+    set -l panes $TMUX_PANE
+
+    tmux rename-window -t $TMUX_PANE (basename $current_dir)
+
+    while test (count $panes) -lt $count
+        set -l split_target $panes[-1]
+        set -l new_pane (tmux split-window -h -t $split_target -c $current_dir -P -F '#{pane_id}')
+        set -a panes $new_pane
+        tmux select-layout -t $panes[1] tiled
+    end
+
+    for pane in $panes
+        tmux send-keys -t $pane "$cmd" C-m
+    end
+
+    tmux select-pane -t $panes[1]
+end


### PR DESCRIPTION
## Summary
- Add 3 missing tmux functions: tdl, tdlm, tsl
- Add omarchy/bin and .local/bin to PATH in envs.fish

## Changes
### New Functions
- tdl: Creates tmux layout with editor, AI, and terminal panes
- tdlm: Creates multiple tdl windows for each subdirectory  
- tsl: Creates tmux swarm layout (same command in multiple panes)

### PATH Integration
- Added fish_add_path for omarchy/bin and .local/bin

These were the only significant gaps identified between the bash rc and fish extension.