### PR TITLE
Add omarchy completions and dev helpers

### DIFF
--- a/bin/dev-link
+++ b/bin/dev-link
@@ -1,0 +1,39 @@
+#!/bin/bash
+set -euo pipefail
+
+REPO="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+VENDOR_BASE="${XDG_DATA_HOME:-$HOME/.local/share}/fish"
+
+# Match the PKGBUILD: include leading-dot function names like ....fish
+shopt -s dotglob
+
+declare -A DIRS=(
+  [functions]=vendor_functions.d
+  [conf.d]=vendor_conf.d
+  [completions]=vendor_completions.d
+)
+
+linked=0
+for src in "${!DIRS[@]}"; do
+  src_dir="$REPO/$src"
+  dst_dir="$VENDOR_BASE/${DIRS[$src]}"
+  [[ -d $src_dir ]] || continue
+  mkdir -p "$dst_dir"
+  for f in "$src_dir"/*.fish; do
+    [[ -e $f ]] || continue
+    ln -snf "$f" "$dst_dir/$(basename "$f")"
+    linked=$((linked + 1))
+  done
+done
+
+# Drop a conf.d snippet so every new interactive fish prints a reminder that
+# the working tree is shadowing the packaged version. Removed by dev-unlink.
+BANNER="$VENDOR_BASE/vendor_conf.d/__omarchy-fish-dev-banner.fish"
+cat >"$BANNER" <<EOF
+status is-interactive; or return
+printf '\e[33m⚠ omarchy-fish dev linked: \e[1m%s\e[22m — run "bin/dev-unlink" to restore packaged version\e[0m\n' '$REPO'
+EOF
+
+echo "Linked $linked file(s) from $REPO into $VENDOR_BASE/vendor_*.d/"
+echo "Functions and completions hot-reload on next call."
+echo "For conf.d edits to take effect, open a new fish shell."

--- a/bin/dev-pkg-test
+++ b/bin/dev-pkg-test
@@ -1,0 +1,48 @@
+#!/bin/bash
+set -euo pipefail
+
+REPO="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+PKGBUILD_SRC="${1:-$HOME/Work/omarchy/omarchy-pkgs/pkgbuilds/edge/omarchy-fish}"
+
+if [[ ! -f $PKGBUILD_SRC/PKGBUILD ]]; then
+  echo "PKGBUILD not found in: $PKGBUILD_SRC" >&2
+  echo "Pass the directory containing PKGBUILD as the first argument." >&2
+  exit 1
+fi
+
+pkgname=$(awk -F= '/^pkgname=/ {gsub(/[" ]/,"",$2); print $2; exit}' "$PKGBUILD_SRC/PKGBUILD")
+
+# Always tag dev builds with the commit hash so `pacman -Q` makes it obvious
+# the installed version came from this script and points back at a specific
+# commit. `.dirty` if the working tree has uncommitted edits.
+short_sha=$(git -C "$REPO" rev-parse --short HEAD)
+dirty=""
+# --porcelain catches modified, staged, and untracked-not-ignored files —
+# i.e. anything `git ls-files -co --exclude-standard` will pull into the tarball.
+if [[ -n $(git -C "$REPO" status --porcelain) ]]; then
+  dirty=".dirty"
+fi
+pkgver="dev.${short_sha}${dirty}"
+
+build_dir=$(mktemp -d -t omarchy-fish-pkg-test.XXXXXX)
+trap 'rm -rf "$build_dir"' EXIT
+
+cp -a "$PKGBUILD_SRC"/. "$build_dir/"
+sed -i "s/^pkgver=.*/pkgver=${pkgver}/" "$build_dir/PKGBUILD"
+
+# Replace the upstream tarball with one built from the working tree.
+# `git ls-files -co --exclude-standard` includes tracked + untracked-not-ignored
+# files, read from disk, so uncommitted edits are picked up.
+(
+  cd "$REPO"
+  git ls-files -co --exclude-standard -z |
+    tar --null --transform "s,^,${pkgname}-${pkgver}/," \
+        -czf "$build_dir/${pkgname}-${pkgver}.tar.gz" -T -
+)
+
+echo "Building ${pkgname} ${pkgver} (tarball: ${pkgname}-${pkgver}.tar.gz)"
+echo "makepkg working dir: $build_dir"
+echo
+
+cd "$build_dir"
+makepkg -si --skipchecksums "${@:2}"

--- a/bin/dev-unlink
+++ b/bin/dev-unlink
@@ -1,0 +1,32 @@
+#!/bin/bash
+set -euo pipefail
+
+REPO="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+VENDOR_BASE="${XDG_DATA_HOME:-$HOME/.local/share}/fish"
+
+# Match dev-link: include leading-dot symlinks like ....fish
+shopt -s dotglob
+
+removed=0
+for dst_dir in "$VENDOR_BASE"/vendor_functions.d "$VENDOR_BASE"/vendor_conf.d "$VENDOR_BASE"/vendor_completions.d; do
+  [[ -d $dst_dir ]] || continue
+  for link in "$dst_dir"/*; do
+    [[ -L $link ]] || continue
+    target="$(readlink -- "$link")"
+    case "$target" in
+      "$REPO"/*)
+        rm -- "$link"
+        removed=$((removed + 1))
+        ;;
+    esac
+  done
+done
+
+BANNER="$VENDOR_BASE/vendor_conf.d/__omarchy-fish-dev-banner.fish"
+if [[ -f $BANNER ]]; then
+  rm -- "$BANNER"
+  removed=$((removed + 1))
+fi
+
+echo "Removed $removed dev file(s) for $REPO"
+echo "Open a new fish shell to drop dev-linked conf.d from this session."

--- a/completions/omarchy.fish
+++ b/completions/omarchy.fish
@@ -1,0 +1,48 @@
+function __omarchy_complete
+    set -l tokens (commandline -opc)
+
+    set -l omarchy_path (command -v omarchy 2>/dev/null); or return 0
+    set -l resolved (realpath -- $omarchy_path 2>/dev/null); or set resolved $omarchy_path
+    set -l bin_dir (dirname -- $resolved)
+    test -d $bin_dir; or return 0
+
+    set -l prefix omarchy
+    set -l positional_count 0
+    for tok in $tokens[2..]
+        test -z "$tok"; and continue
+        string match -q -- '-*' $tok; and continue
+        set prefix $prefix-$tok
+        set positional_count (math $positional_count + 1)
+    end
+
+    set -l seen
+    for file in $bin_dir/$prefix-*
+        test -f $file -a -x $file; or continue
+        set -l basename (string replace -r '^.*/' '' -- $file)
+        set -l rest (string replace -- $prefix- '' $basename)
+        set -l next (string split -m 1 -- - $rest)[1]
+        test -n "$next"; or continue
+        contains -- $next $seen; and continue
+        set -a seen $next
+        echo $next
+    end
+
+    if test $positional_count -eq 0
+        echo commands
+        set -a seen commands
+    end
+
+    if test (count $tokens) -ge 2 -a "$tokens[2]" = commands
+        echo --all
+        echo --json
+        echo --markdown
+        echo --check
+        set -a seen --all
+    end
+
+    if test -x $bin_dir/$prefix -o (count $seen) -gt 0
+        echo --help
+    end
+end
+
+complete -c omarchy -f -a '(__omarchy_complete)'


### PR DESCRIPTION
## Summary
- New \`completions/omarchy.fish\` mirrors the upstream bash completion logic — walks \`omarchy-*\` siblings of the dispatcher to build subcommand candidates, plus the \`commands\` / \`--all|--json|--markdown|--check\` / \`--help\` cases.
- Dev workflow under \`bin/\` for iterating without a push/tag/release cycle:
  - \`bin/dev-link\` — symlinks \`functions/\`, \`conf.d/\`, \`completions/\` from the working tree into \`~/.local/share/fish/vendor_*.d/\`, which fish autoloads ahead of the packaged \`/usr/share/\` versions. Drops a yellow startup banner so it's obvious you're shadowing the package. Includes \`shopt -s dotglob\` so leading-dot function aliases (\`....fish\`, \`.....fish\`) are mirrored.
  - \`bin/dev-unlink\` — removes only symlinks pointing back into the repo, plus the banner.
  - \`bin/dev-pkg-test\` — tarballs the working tree (\`git ls-files -co --exclude-standard\`, so uncommitted edits ride along), patches the PKGBUILD copy with \`pkgver=dev.<short-sha>\` (\`.dirty\` suffix when the working tree isn't clean), and runs \`makepkg -si --skipchecksums\`. Validates the actual packaging path with no GitHub round-trip, and \`pacman -Q\` makes it obvious which commit is installed.